### PR TITLE
AT2-37 Updating readme for react skeleton as part of developer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # ska-webapps-skeleton
 
-This project is intended to act as a skeleton for any SKA developer looking to make a javascript based web application.
+This project is intended to act as a skeleton for any SKA developer looking to make a javascript based web application.  It acts as a placeholder for any common skeleton files that are shared between the different types of web application.
 
-It currently contains the following skeleton
+It also contains a set of skeleton project structures. One for each of the different types of web application currently being developed by the SKA.
+
+The skeletons it contains are designed to provide an outline structure and a configured set of the tools needed for developing a web project using the given framework.
+
+All the documentation for linting, code formatting, and testing each type of project can be found in the README file for the relevant skeleton.
+
+This project currently contains the following skeleton
 
 * __ska-webapps-react-skeleton__:
   This is a project is intended to act as a skeleton for any SKA developer looking to make a React based web application. [README](./ska-webapps-react-skeleton/README.md)
-
-All the documentation for linting, code formatting, and testing each type of project can be found in the README file for the type of skeleton.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # ska-webapps-skeleton
-This is the github skeleton for all javascript based web applications developed under SKA
+
+This project is intended to act as a skeleton for any SKA developer looking to make a javascript based web application.
+
+It currently contains the following skeleton
+
+* __ska-webapps-react-skeleton__:
+  This is a project is intended to act as a skeleton for any SKA developer looking to make a React based web application. [README](./ska-webapps-react-skeleton/README.md)
+
+All the documentation for linting, code formatting, and testing each type of project can be found in the README file for the type of skeleton.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ska-webapps-skeleton
 
-This project is intended to act as a skeleton for any SKA developer looking to make a javascript based web application.  It acts as a placeholder for any common skeleton files that are shared between the different types of web application.
+This project is intended to act as a skeleton for any SKA developer looking to make a javascript based web application.  It acts as a placeholder for any common files or components that are shared between the different types of web application.
 
 It also contains a set of skeleton project structures. One for each of the different types of web application currently being developed by the SKA.
 

--- a/ska-webapps-react-skeleton/.eslintignore
+++ b/ska-webapps-react-skeleton/.eslintignore
@@ -1,3 +1,4 @@
-./src/serviceWorker.js
+/src/resources/logo.svg
 node_modules
 coverage
+**/*.css

--- a/ska-webapps-react-skeleton/README.md
+++ b/ska-webapps-react-skeleton/README.md
@@ -49,6 +49,45 @@ Your app is ready to be deployed!
 
 See the create-react-app [deployment guide](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
+## Testing ##
+
+We use Jest as the test running framework. It will look for test files with any of the following popular naming conventions:
+
+* Files with .js suffix in `__tests__` folders.
+* Files with .test.js suffix in any folder.
+* Files with .spec.js suffix in any folder.
+
+The .test.js / .spec.js files (or the `__tests__` folders) can be located at any depth under the src top level folder.
+We recommend to put the test files (or `__tests__` folders) next to the code they are testing
+
+Run tests interactively with  
+
+    > npm test 
+
+Jest also provides  the code analysis framework. 
+
+Running the tests will create (or update) reports for style and code coverage inside the  htmlcov folder
+
+Inside this folder a rundown of the issues found will be accessible using the index.html file
+All the tests should pass before merging the code
+
+By default it uses the airBnB default  style rules see: [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript).
+
+Code analysis should only raise document related warnings (i.e. #FIXME comments) before merging the code
+
+## Writing documentation ##
+
+The documentation generator for this project is derived from SKA's [SKA Developer Portal repository](http://developer.skatelescope.org/en/latest/projects/document_project.html)
+
+The documentation can be edited under `./docs/src`
+
+In order to build the documentation for this specific project, execute the following under ./docs:
+
+    > make html
+
+The documentation can then be consulted by opening the file `./docs/build/html/index.html`
+
+
 ## Ejecting the underlying create-react-app framework ##
 
 The current skeleton was bootstrapped with Create React App and uses the provided default build tool and configuration choices. If you wish to extend or configure your own choices you can eject at any time. 

--- a/ska-webapps-react-skeleton/README.md
+++ b/ska-webapps-react-skeleton/README.md
@@ -1,14 +1,19 @@
-This project was originally bootstrapped with [Create React App](https://github.com/facebook/create-react-app). It relies on having node  and the node package manager (npm) installed locally.
+# SKA React Web App Skeleton #
+This project is intended to act as a skeleton for any SKA developer looking to make a React based web application.
+
+It includes tools for linting, code formatting, and testing which are easily integrated into various IDEs.
+
+## Requirements ##
+
+This skeleton requires **Node** and **NPM** to install and run. To install these follow the instructions for your operating system at [https://nodejs.org/en/download/](https://nodejs.org/en/download/).
+
+Alternatively the official Node docker image can be used. Instructions can be found on  the [official Node docker image site](https://github.com/nodejs/docker-node/blob/master/README.md#how-to-use-this-image).
 
 ## Installation ##
 
-To install node (and npm) follow the instructions for your operating system at [https://nodejs.org/en/download/](https://nodejs.org/en/download/).  
+*All the following notes assume you are at the command prompt for your chosen environment.*
 
-If you prefer to use a docker image for your development instructions can be found on  the [official node docker image site](https://github.com/nodejs/docker-node/blob/master/README.md#how-to-use-this-image)
-
-All the following notes assume you are at the command prompt for your chosen environment.
-
-To confirm node and nmp are installed and configured correctly, both the following commands should return the relevant version number.
+To confirm Node and Npm are installed and configured correctly, both the following commands should return the relevant version number.
 
     > node --version
     > npm --version

--- a/ska-webapps-react-skeleton/README.md
+++ b/ska-webapps-react-skeleton/README.md
@@ -6,6 +6,8 @@ To install node (and npm) follow the instructions for your operating system at [
 
 If you prefer to use a docker image for your development instructions can be found on  the [official node docker image site](https://github.com/nodejs/docker-node/blob/master/README.md#how-to-use-this-image)
 
+All the following notes assume you are at the command prompt for your chosen environment.
+
 To confirm node and nmp are installed and configured correctly, both the following commands should return the relevant version number.
 
     > node --version
@@ -19,8 +21,8 @@ Install all the necessary project dependencies by running
 
 ## Running and building the application ##
 
-Scripts are provided as part of the standard configuration. These are run from npm, configured in the scripts section of the package.json file. 
-The scripts themselves can be found in the installed node package create-react-apps. These are currently the same as the defaults supplied as part of create-react-apps. 
+Scripts are provided as part of the standard configuration. These are run from npm, configured in the scripts section of the package.json file.
+The scripts themselves can be found in the installed node package create-react-apps. These are currently the same as the defaults supplied as part of create-react-apps.
 
 If you need to change these see the section on __Ejecting the underlying create-react-app framework__ below.
 
@@ -28,23 +30,28 @@ From the project directory, you can run any of the following
 
     > npm start
 
-Runs the app in the development mode.<br>
+Runs the app in the development mode.
+
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 
-The page will reload if you make edits.<br>
+The page will reload if you make edits.
+
 You will also see any lint errors in the console.
 
     > npm test
 
-Launches the test runner in the interactive watch mode.<br>
+Launches the test runner in the interactive watch mode.
+
 See the section below about __testing__ for more information.
 
     > npm run build
 
-Builds the app for production to the `build` folder.<br>
-It correctly bundles React in production mode and optimizes the build for the best performance.
+Builds the app for production to the `build` folder.
 
-The build is minified and the filenames include the hashes.<br>
+It correctly bundles React in production mode and optimises the build for the best performance.
+
+The build is minified and the filenames include the hashes.
+
 Your app is ready to be deployed!
 
 See the create-react-app [deployment guide](https://facebook.github.io/create-react-app/docs/deployment) for more information.
@@ -62,18 +69,26 @@ We recommend to put the test files (or `__tests__` folders) next to the code the
 
 Run tests interactively with  
 
-    > npm test 
+    > npm test
 
-Jest also provides  the code analysis framework. 
+Jest also provides  the code analysis framework. To run a full set of tests including coverage statistics run:
 
-Running the tests will create (or update) reports for style and code coverage inside the  htmlcov folder
+    > npm run-script test:coverage
 
-Inside this folder a rundown of the issues found will be accessible using the index.html file
+Running this command will run all the tests and also check the code style and test coverage.
+By default it uses the airBnB default style rules see: [AirBnB JavaScript Style Guide](https://github.com/airbnb/javascript).
+
+The results are displayed in the console. They are also written to the  `coverage` folder as:
+
+* `lcov-report` - a coverage report as a series of html pages
+* `clover.xml`  - A clover coverage report that can be viewed in the clover code-coverage tools
+* `coverage-final.json` - A json format.
+
+The  `coverage\lcov-report\`  folder contains a readable rundown of the issues found  which is accessible using the `index.html` file
+
+Code analysis should only raise document related warnings (i.e. // FIXME: comments) before merging the code. 
+
 All the tests should pass before merging the code
-
-By default it uses the airBnB default  style rules see: [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript).
-
-Code analysis should only raise document related warnings (i.e. #FIXME comments) before merging the code
 
 ## Writing documentation ##
 
@@ -87,12 +102,11 @@ In order to build the documentation for this specific project, execute the follo
 
 The documentation can then be consulted by opening the file `./docs/build/html/index.html`
 
-
 ## Ejecting the underlying create-react-app framework ##
 
-The current skeleton was bootstrapped with Create React App and uses the provided default build tool and configuration choices. If you wish to extend or configure your own choices you can eject at any time. 
+The current skeleton was bootstrapped with Create React App and uses the provided default build tool and configuration choices. If you wish to extend or configure your own choices you can eject at any time.
 
-You don’t have to ever use eject. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+You don’t have to ever use eject. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customise it when you are ready for it.
 
     > npm run eject
 
@@ -110,24 +124,24 @@ To learn React, check out the [React documentation](https://reactjs.org/).
 
 ### Code Splitting ##
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
+This section has moved here: <https://facebook.github.io/create-react-app/docs/code-splitting>
 
-### Analyzing the Bundle Size ##
+### Analysing the Bundle Size ##
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
+This section has moved here: <https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size>
 
 ### Making a Progressive Web App ##
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
+This section has moved here: <https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app>
 
 ### Advanced Configuration ##
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
+This section has moved here: <https://facebook.github.io/create-react-app/docs/advanced-configuration>
 
 ### Deployment ##
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
+This section has moved here: <https://facebook.github.io/create-react-app/docs/deployment>
 
 ### `npm run build` fails to minify ##
 
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify
+This section has moved here: <https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify>

--- a/ska-webapps-react-skeleton/README.md
+++ b/ska-webapps-react-skeleton/README.md
@@ -1,4 +1,4 @@
-This project was originally bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This project was originally bootstrapped with [Create React App](https://github.com/facebook/create-react-app). It relies on having node  and the node package manager (npm) installed locally.
 
 ## Installation ##
 

--- a/ska-webapps-react-skeleton/README.md
+++ b/ska-webapps-react-skeleton/README.md
@@ -1,152 +1,144 @@
-# SKA React Web App Skeleton #
+# SKA React Web App Skeleton
+
 This project is intended to act as a skeleton for any SKA developer looking to make a React based web application.
 
 It includes tools for linting, code formatting, and testing which are easily integrated into various IDEs.
 
-## Requirements ##
+## Requirements
 
 This skeleton requires **Node** and **NPM** to install and run. To install these follow the instructions for your operating system at [https://nodejs.org/en/download/](https://nodejs.org/en/download/).
 
-Alternatively the official Node docker image can be used. Instructions can be found on  the [official Node docker image site](https://github.com/nodejs/docker-node/blob/master/README.md#how-to-use-this-image).
+Alternatively the official Node docker image can be used. Instructions can be found on the [official Node docker image site](https://github.com/nodejs/docker-node/blob/master/README.md#how-to-use-this-image).
 
-## Installation ##
+## Installation
 
-*All the following notes assume you are at the command prompt for your chosen environment.*
+_All the following notes assume you are at the command prompt for your chosen environment._
 
-To confirm Node and Npm are installed and configured correctly, both the following commands should return the relevant version number.
+1.  Confirm Node and NPM are installed and configured correctly, both the following commands should return the relevant version number.
 
-    > node --version
-    > npm --version
+        > node --version
+        > npm --version
 
-Clone the project from git, and follow these steps at the project root:
+2.  Clone the project from GitHub
 
-Install all the necessary project dependencies by running
+3.  Install all the necessary project dependencies by running
 
-    > npm install
+        > npm install
 
-## Running and building the application ##
+## Running and Building the Application
 
-Scripts are provided as part of the standard configuration. These are run from npm, configured in the scripts section of the package.json file.
-The scripts themselves can be found in the installed node package create-react-apps. These are currently the same as the defaults supplied as part of create-react-apps.
+Scripts for running, testing, and building the application are provided as part of the standard configuration. These are run using NPM and listed in the scripts section of the package.json file.
 
-If you need to change these see the section on __Ejecting the underlying create-react-app framework__ below.
+From the project directory, you can run any of the following:
 
-From the project directory, you can run any of the following
+- `> npm start`
 
-    > npm start
+  Runs the app in the development mode at [http://localhost:3000](http://localhost:3000). The app will recompile and restart if you make any edits to the source files. Any linting errors will also be shown in the console.
 
-Runs the app in the development mode.
+- `> npm test`
 
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+  Launches the test runner in the interactive watch mode. See the [testing](#testing) section for more information.
 
-The page will reload if you make edits.
+- `> npm run build`
 
-You will also see any lint errors in the console.
+  Builds the app for production to the `build` folder. The build is minified and any JSX is transpiled to JavaScript. Your app is ready to be deployed!
 
-    > npm test
+## Testing
 
-Launches the test runner in the interactive watch mode.
+### Writing
 
-See the section below about __testing__ for more information.
+We use Jest as the test running framework. It will look for test files with any of the following naming conventions:
 
-    > npm run build
-
-Builds the app for production to the `build` folder.
-
-It correctly bundles React in production mode and optimises the build for the best performance.
-
-The build is minified and the filenames include the hashes.
-
-Your app is ready to be deployed!
-
-See the create-react-app [deployment guide](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-## Testing ##
-
-We use Jest as the test running framework. It will look for test files with any of the following popular naming conventions:
-
-* Files with .js suffix in `__tests__` folders.
-* Files with .test.js suffix in any folder.
-* Files with .spec.js suffix in any folder.
+- Files with `.js` suffix in `__tests__` folders.
+- Files with `.test.js` suffix in any folder.
+- Files with `.spec.js` suffix in any folder.
 
 The .test.js / .spec.js files (or the `__tests__` folders) can be located at any depth under the src top level folder.
-We recommend to put the test files (or `__tests__` folders) next to the code they are testing
+We recommend to put the test files or folders next to the code they are testing.
 
-Run tests interactively with  
+```
+components
+|
+└─ App
+   |  App.jsx
+   |  App.test.jsx
+```
+
+[Enzyme](https://airbnb.io/enzyme/) and [jest-enzyme](https://www.npmjs.com/package/jest-enzyme) have been included to improve the testing framework and test readability.
+
+See the developer guide for more information
+
+### Running
+
+To run the interactive test runner, execute
 
     > npm test
 
-Jest also provides  the code analysis framework. To run a full set of tests including coverage statistics run:
+This will also watch the source files and re-run when any changes are detected
 
-    > npm run-script test:coverage
+To run the tests with coverage, execute
 
-Running this command will run all the tests and also check the code style and test coverage.
-By default it uses the airBnB default style rules see: [AirBnB JavaScript Style Guide](https://github.com/airbnb/javascript).
+    > npm run test:coverage
 
-The results are displayed in the console. They are also written to the  `coverage` folder as:
+The coverage results are displayed in the console. They are also written to the `coverage` folder as:
 
-* `lcov-report` - a coverage report as a series of html pages
-* `clover.xml`  - A clover coverage report that can be viewed in the clover code-coverage tools
-* `coverage-final.json` - A json format.
+- `lcov-report` - A coverage report as a series of html pages, open `index.html` in a web browser to view
+- `clover.xml` - A clover coverage report that can be viewed in the clover code-coverage tools
+- `coverage-final.json` - A json format.
 
-The  `coverage\lcov-report\`  folder contains a readable rundown of the issues found  which is accessible using the `index.html` file
+**All the tests should pass before merging the code**
 
-Code analysis should only raise document related warnings (i.e. // FIXME: comments) before merging the code. 
+## Code Analysis
 
-All the tests should pass before merging the code
+[ESLint](https://ESLint.org/) and [Prettier](https://prettier.io/) are included as code analysis and formatting tools.
+These do not need installing as they're included in `node_modules` by running `npm install`.
 
-## Writing documentation ##
+These tools can be run in the command line or integrated into your IDE (recommended).
+
+JavaScript based SKA projects must comply with the [AirBnB JavaScript Style Guide](https://github.com/airbnb/javascript). These rules are included in this project and ESLint and Prettier are configured to use them.
+
+### Running
+
+To run the analysis tools, execute
+
+    > npm run code-analysis
+
+This will display any errors in the command line.
+
+### IDE Integration
+
+#### VS Code
+
+Install the [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-ESLint) and [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) extensions and reload the IDE.
+
+Errors should now show in the editor. `shift + alt + F` will format a file, or you can turn on the format on save setting.
+
+#### JetBrains (WebStorm, IntelliJ IDEA etc.)
+
+ESLint is integrated into the Ultimate versions of all JetBrains IDEs
+
+Prettier can be installed through a [plugin](https://plugins.jetbrains.com/plugin/10456-prettier). Follow the steps [here](https://www.jetbrains.com/help/idea/prettier.html) to configure it.
+
+## Documentation
 
 The documentation generator for this project is derived from SKA's [SKA Developer Portal repository](http://developer.skatelescope.org/en/latest/projects/document_project.html)
 
-The documentation can be edited under `./docs/src`
+### Writing
+
+The documentation can be edited under `./docs/src`. They're written in reStructured text (.rst).
+
+### Building
 
 In order to build the documentation for this specific project, execute the following under ./docs:
 
     > make html
 
+or
+
+    > docker run --rm -d -v $(pwd):/tmp -w /tmp netresearch/sphinx-buildbox sh -c "make html"
+
+The latter requires Docker to be installed on your system but not Python, Sphinx, and other dependencies.
+
 The documentation can then be consulted by opening the file `./docs/build/html/index.html`
 
-## Ejecting the underlying create-react-app framework ##
-
-The current skeleton was bootstrapped with Create React App and uses the provided default build tool and configuration choices. If you wish to extend or configure your own choices you can eject at any time.
-
-You don’t have to ever use eject. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customise it when you are ready for it.
-
-    > npm run eject
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies from create-react-app (Webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except eject will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-## Learn More ##
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting ##
-
-This section has moved here: <https://facebook.github.io/create-react-app/docs/code-splitting>
-
-### Analysing the Bundle Size ##
-
-This section has moved here: <https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size>
-
-### Making a Progressive Web App ##
-
-This section has moved here: <https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app>
-
-### Advanced Configuration ##
-
-This section has moved here: <https://facebook.github.io/create-react-app/docs/advanced-configuration>
-
-### Deployment ##
-
-This section has moved here: <https://facebook.github.io/create-react-app/docs/deployment>
-
-### `npm run build` fails to minify ##
-
-This section has moved here: <https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify>
+:point_right: :red_circle: This guide brought to you by Team buttons

--- a/ska-webapps-react-skeleton/README.md
+++ b/ska-webapps-react-skeleton/README.md
@@ -140,5 +140,3 @@ or
 The latter requires Docker to be installed on your system but not Python, Sphinx, and other dependencies.
 
 The documentation can then be consulted by opening the file `./docs/build/html/index.html`
-
-:point_right: :red_circle: This guide brought to you by Team buttons

--- a/ska-webapps-react-skeleton/README.md
+++ b/ska-webapps-react-skeleton/README.md
@@ -101,9 +101,9 @@ JavaScript based SKA projects must comply with the [AirBnB JavaScript Style Guid
 
 To run the analysis tools, execute
 
-    > npm run code-analysis
+    > npm run code-analysis -s
 
-This will display any errors in the command line.
+This will display any errors in the command line. If there are any errors, NPM will exit with a non-zero code, the `-s` argument suppresses this and cleans up the output.
 
 ### IDE Integration
 

--- a/ska-webapps-react-skeleton/README.md
+++ b/ska-webapps-react-skeleton/README.md
@@ -1,10 +1,32 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+This project was originally bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
-## Available Scripts
+## Installation ##
 
-In the project directory, you can run:
+To install node (and npm) follow the instructions for your operating system at [https://nodejs.org/en/download/](https://nodejs.org/en/download/).  
 
-### `npm start`
+If you prefer to use a docker image for your development instructions can be found on  the [official node docker image site](https://github.com/nodejs/docker-node/blob/master/README.md#how-to-use-this-image)
+
+To confirm node and nmp are installed and configured correctly, both the following commands should return the relevant version number.
+
+    > node --version
+    > npm --version
+
+Clone the project from git, and follow these steps at the project root:
+
+Install all the necessary project dependencies by running
+
+    > npm install
+
+## Running and building the application ##
+
+Scripts are provided as part of the standard configuration. These are run from npm, configured in the scripts section of the package.json file. 
+The scripts themselves can be found in the installed node package create-react-apps. These are currently the same as the defaults supplied as part of create-react-apps. 
+
+If you need to change these see the section on __Ejecting the underlying create-react-app framework__ below.
+
+From the project directory, you can run any of the following
+
+    > npm start
 
 Runs the app in the development mode.<br>
 Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
@@ -12,12 +34,12 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.<br>
 You will also see any lint errors in the console.
 
-### `npm test`
+    > npm test
 
 Launches the test runner in the interactive watch mode.<br>
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+See the section below about __testing__ for more information.
 
-### `npm run build`
+    > npm run build
 
 Builds the app for production to the `build` folder.<br>
 It correctly bundles React in production mode and optimizes the build for the best performance.
@@ -25,44 +47,48 @@ It correctly bundles React in production mode and optimizes the build for the be
 The build is minified and the filenames include the hashes.<br>
 Your app is ready to be deployed!
 
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
+See the create-react-app [deployment guide](https://facebook.github.io/create-react-app/docs/deployment) for more information.
 
-### `npm run eject`
+## Ejecting the underlying create-react-app framework ##
+
+The current skeleton was bootstrapped with Create React App and uses the provided default build tool and configuration choices. If you wish to extend or configure your own choices you can eject at any time. 
+
+You don’t have to ever use eject. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
+
+    > npm run eject
 
 **Note: this is a one-way operation. Once you `eject`, you can’t go back!**
 
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
+This command will remove the single build dependency from your project.
 
-Instead, it will copy all the configuration files and the transitive dependencies (Webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
+Instead, it will copy all the configuration files and the transitive dependencies from create-react-app (Webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except eject will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
 
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
+## Learn More ##
 
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
 
-### Code Splitting
+### Code Splitting ##
 
 This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
 
-### Analyzing the Bundle Size
+### Analyzing the Bundle Size ##
 
 This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
 
-### Making a Progressive Web App
+### Making a Progressive Web App ##
 
 This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
 
-### Advanced Configuration
+### Advanced Configuration ##
 
 This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
 
-### Deployment
+### Deployment ##
 
 This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
 
-### `npm run build` fails to minify
+### `npm run build` fails to minify ##
 
 This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify

--- a/ska-webapps-react-skeleton/package-lock.json
+++ b/ska-webapps-react-skeleton/package-lock.json
@@ -5908,11 +5908,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5925,15 +5927,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6036,7 +6041,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6046,6 +6052,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6058,17 +6065,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6085,6 +6095,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6157,7 +6168,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6167,6 +6179,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6272,6 +6285,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/ska-webapps-react-skeleton/package.json
+++ b/ska-webapps-react-skeleton/package.json
@@ -7,6 +7,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test:coverage": "react-scripts test \"--coverage\"",
+    "code-analysis": "./node_modules/.bin/eslint \"src/**\" --ignore-path .eslintignore",
     "eject": "react-scripts eject"
   },
   "dependencies": {


### PR DESCRIPTION
This provides more info for developers on how to use the ska-webapps-react-skeleton. 
Basically, how to build and test an application built using the skeleton described at a level more in line with the readme provided for the ska-python-skeleton. 
It incorporates changes made to the scripts provided as part of AT-37.